### PR TITLE
refactor: expose context via hooks. use reducer and dispatch.

### DIFF
--- a/__tests__/components/common/Carousel.test.tsx
+++ b/__tests__/components/common/Carousel.test.tsx
@@ -14,7 +14,6 @@ const mockRenderFunction = jest
     ))
 
 const mockOnSelectedIndexChanged = jest.fn()
-const mockOnSelectedItemChanged = jest.fn()
 
 describe('Carousel', () => {
     test('renders children items according to render function', () => {
@@ -24,7 +23,6 @@ describe('Carousel', () => {
                 selectedIndex={0}
                 onRenderItem={mockRenderFunction}
                 onSelectedIndexChanged={mockOnSelectedIndexChanged}
-                onSelectedItemChanged={mockOnSelectedItemChanged}
             />
         )
 
@@ -41,7 +39,6 @@ describe('Carousel', () => {
                 selectedIndex={0}
                 onRenderItem={mockRenderFunction}
                 onSelectedIndexChanged={mockOnSelectedIndexChanged}
-                onSelectedItemChanged={mockOnSelectedItemChanged}
             />
         )
 
@@ -60,7 +57,6 @@ describe('Carousel', () => {
                 selectedIndex={items.length - 1}
                 onRenderItem={mockRenderFunction}
                 onSelectedIndexChanged={mockOnSelectedIndexChanged}
-                onSelectedItemChanged={mockOnSelectedItemChanged}
             />
         )
 
@@ -81,7 +77,6 @@ describe('Carousel', () => {
                 selectedIndex={startIndex}
                 onRenderItem={mockRenderFunction}
                 onSelectedIndexChanged={mockOnSelectedIndexChanged}
-                onSelectedItemChanged={mockOnSelectedItemChanged}
             />
         )
 
@@ -102,7 +97,6 @@ describe('Carousel', () => {
                 selectedIndex={startIndex}
                 onRenderItem={mockRenderFunction}
                 onSelectedIndexChanged={mockOnSelectedIndexChanged}
-                onSelectedItemChanged={mockOnSelectedItemChanged}
             />
         )
 
@@ -123,7 +117,6 @@ describe('Carousel', () => {
                 selectedIndex={startIndex}
                 onRenderItem={mockRenderFunction}
                 onSelectedIndexChanged={mockOnSelectedIndexChanged}
-                onSelectedItemChanged={mockOnSelectedItemChanged}
             />
         )
 
@@ -144,7 +137,6 @@ describe('Carousel', () => {
                 selectedIndex={startIndex}
                 onRenderItem={mockRenderFunction}
                 onSelectedIndexChanged={mockOnSelectedIndexChanged}
-                onSelectedItemChanged={mockOnSelectedItemChanged}
             />
         )
 

--- a/components/common/Carousel.tsx
+++ b/components/common/Carousel.tsx
@@ -1,5 +1,5 @@
 import { Box, Icon } from '@chakra-ui/react'
-import React, { ReactNode, useCallback, useEffect } from 'react'
+import React, { ReactNode, useCallback } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { FaArrowLeft, FaArrowRight } from 'react-icons/fa'
 import { strings } from '../../constants/strings'
@@ -11,7 +11,6 @@ type Props<ItemType> = {
     selectedIndex: number
     onRenderItem: (item: ItemType, index: number) => ReactNode
     onSelectedIndexChanged: (index: number) => void
-    onSelectedItemChanged?: (item: ItemType) => void
 }
 
 function Carousel<ItemType>({
@@ -19,7 +18,6 @@ function Carousel<ItemType>({
     selectedIndex = 0,
     onRenderItem,
     onSelectedIndexChanged,
-    onSelectedItemChanged,
 }: Props<ItemType>) {
     const movePrevious = useCallback(() => {
         if (selectedIndex === 0) return
@@ -30,10 +28,6 @@ function Carousel<ItemType>({
         if (selectedIndex === items.length - 1) return
         onSelectedIndexChanged(selectedIndex + 1)
     }, [selectedIndex, onSelectedIndexChanged, items.length])
-
-    useEffect(() => {
-        onSelectedItemChanged?.(items[selectedIndex])
-    }, [selectedIndex, items, onSelectedItemChanged])
 
     useHotkeys('left', movePrevious, { keydown: true }, [movePrevious])
     useHotkeys('right', moveNext, { keydown: true }, [moveNext])

--- a/components/species_catalog/SpeciesCatalog.tsx
+++ b/components/species_catalog/SpeciesCatalog.tsx
@@ -1,15 +1,12 @@
 import { Box, Center, Flex, Spinner } from '@chakra-ui/react'
-import React, { useContext } from 'react'
-import {
-    CatalogContext,
-    CatalogContextProps,
-} from '../../contexts/CatalogContext'
+import React from 'react'
+import { useCatalogContext } from '../../contexts/CatalogContext'
 import SpeciesDetails from './SpeciesDetails'
 import SpeciesSelector from './SpeciesSelector'
 import SpeciesThumbnails from './SpeciesThumbnails'
 
 const SpeciesCatalog: React.FC = ({}) => {
-    const { isLoading } = useContext(CatalogContext) as CatalogContextProps
+    const { isLoading } = useCatalogContext()
 
     return (
         <Flex

--- a/components/species_catalog/SpeciesDetails.tsx
+++ b/components/species_catalog/SpeciesDetails.tsx
@@ -1,16 +1,11 @@
 import { Heading, Stack } from '@chakra-ui/react'
-import React, { useContext } from 'react'
-import {
-    CatalogContext,
-    CatalogContextProps,
-} from '../../contexts/CatalogContext'
+import React from 'react'
+import { useCatalogContext } from '../../contexts/CatalogContext'
 import { getSpeciesDetails } from '../../utils/species'
 import SpeciesDetailsList from '../common/SpeciesDetailsList'
 
 const SpeciesDetails: React.FC = () => {
-    const { selectedSpecies } = useContext(
-        CatalogContext
-    ) as CatalogContextProps
+    const { selectedSpecies } = useCatalogContext()
 
     const details = selectedSpecies ? getSpeciesDetails(selectedSpecies) : []
 

--- a/components/species_catalog/SpeciesSelector.tsx
+++ b/components/species_catalog/SpeciesSelector.tsx
@@ -8,12 +8,9 @@ import {
     useBreakpointValue,
 } from '@chakra-ui/react'
 import { Category, Species, UVCLevel } from '@prisma/client'
-import React, { useContext } from 'react'
+import React from 'react'
 import { strings } from '../../constants/strings'
-import {
-    CatalogContext,
-    CatalogContextProps,
-} from '../../contexts/CatalogContext'
+import { useCatalogContext } from '../../contexts/CatalogContext'
 import { isUVCCategory } from '../../utils/uvcDefinitions'
 import SelectableList from '../common/SelectableList'
 
@@ -21,25 +18,15 @@ const SpeciesSelector: React.FC = () => {
     const {
         speciesList,
         selectedSpecies,
-        setSelectedSpecies,
         selectedCategory,
-        setSelectedCategory,
         selectedUVCLevel,
-        setSelectedUVCLevel,
-    } = useContext(CatalogContext) as CatalogContextProps
+        dispatch,
+    } = useCatalogContext()
 
     const isMobileView = useBreakpointValue({
         base: true,
         md: false,
     })
-
-    // After a new category is loaded, auto select the first item
-    if (
-        speciesList?.length &&
-        !speciesList.find((species) => species === selectedSpecies)
-    ) {
-        setSelectedSpecies(speciesList[0])
-    }
 
     return (
         <Stack spacing={3} w={'100%'} boxSize="full">
@@ -52,7 +39,7 @@ const SpeciesSelector: React.FC = () => {
                                 Category[
                                     event.target.value as keyof typeof Category
                                 ]
-                            setSelectedCategory(category)
+                            dispatch({ type: 'selectCategory', category })
                         }}
                         value={selectedCategory}
                     >
@@ -89,7 +76,7 @@ const SpeciesSelector: React.FC = () => {
                                 UVCLevel[
                                     event.target.value as keyof typeof UVCLevel
                                 ]
-                            setSelectedUVCLevel(uvcLevel)
+                            dispatch({ type: 'selectUVCLevel', uvcLevel })
                         }}
                     >
                         <option value={UVCLevel.Indicator}>
@@ -118,7 +105,7 @@ const SpeciesSelector: React.FC = () => {
                                 )
                             }
 
-                            setSelectedSpecies(species)
+                            dispatch({ type: 'selectSpecies', species })
                         }}
                     >
                         {speciesList.map((species) => (
@@ -134,7 +121,9 @@ const SpeciesSelector: React.FC = () => {
                 <SelectableList<Species>
                     items={speciesList}
                     selectedItem={selectedSpecies}
-                    onSelectedItemChanged={setSelectedSpecies}
+                    onSelectedItemChanged={(species) =>
+                        dispatch({ type: 'selectSpecies', species })
+                    }
                     onRenderItem={(species) => <Text>{species.name}</Text>}
                 />
             )}

--- a/components/species_catalog/SpeciesThumbnails.tsx
+++ b/components/species_catalog/SpeciesThumbnails.tsx
@@ -1,12 +1,9 @@
 import { Grid } from '@chakra-ui/react'
 import { Species } from '@prisma/client'
-import React, { useContext, useState } from 'react'
+import React, { useState } from 'react'
 import usePortal from 'react-useportal'
 import urljoin from 'url-join'
-import {
-    CatalogContext,
-    CatalogContextProps,
-} from '../../contexts/CatalogContext'
+import { useCatalogContext } from '../../contexts/CatalogContext'
 import useLockBodyScroll from '../../hooks/useLockBodyScroll'
 import { getImagePathForSpecies } from '../../utils/species'
 import ImageGallery from './ImageGallery'
@@ -23,9 +20,7 @@ function createImageSources(species: Species) {
 }
 
 const SpeciesThumbnails: React.FC = () => {
-    const { selectedSpecies } = useContext(
-        CatalogContext
-    ) as CatalogContextProps
+    const { selectedSpecies } = useCatalogContext()
 
     const [galleryStartIndex, setGalleryStartIndex] = useState(0)
     const {

--- a/components/tutorial/Tutorial.tsx
+++ b/components/tutorial/Tutorial.tsx
@@ -6,12 +6,9 @@ import {
     Text,
     useDisclosure,
 } from '@chakra-ui/react'
-import React, { useContext } from 'react'
+import React from 'react'
 import { strings } from '../../constants/strings'
-import {
-    TutorialContext,
-    TutorialContextProps,
-} from '../../contexts/TutorialContext'
+import { useTutorialContext } from '../../contexts/TutorialContext'
 import { Question } from '../../types/tutorial'
 import { getSpeciesDetails, isNASpecies } from '../../utils/species'
 import { formatString } from '../../utils/strings'
@@ -29,12 +26,10 @@ const Tutorial: React.FC = () => {
         isLoading,
         error,
         isAnswersScreenVisible,
-        setIsCurrentAnswerVisible,
-        setSelectedQuestionIndex,
         selectedQuestion,
-        setSelectedQuestion,
         selectedQuestionIndex,
-    } = useContext(TutorialContext) as TutorialContextProps
+        dispatch,
+    } = useTutorialContext()
 
     const {
         isOpen: isInfoDialogOpen,
@@ -43,8 +38,7 @@ const Tutorial: React.FC = () => {
     } = useDisclosure()
 
     const onSelectedIndexChanged = (index: number) => {
-        setIsCurrentAnswerVisible(false)
-        setSelectedQuestionIndex(index)
+        dispatch({ type: 'setSelectedQuestionIndex', index })
     }
 
     if (isLoading) {
@@ -95,7 +89,6 @@ const Tutorial: React.FC = () => {
                             items={tutorial.questions}
                             onSelectedIndexChanged={onSelectedIndexChanged}
                             selectedIndex={selectedQuestionIndex}
-                            onSelectedItemChanged={setSelectedQuestion}
                             onRenderItem={(question, index) => (
                                 <TutorialItem
                                     key={`question-${index}`}

--- a/components/tutorial/TutorialAnswers.tsx
+++ b/components/tutorial/TutorialAnswers.tsx
@@ -6,16 +6,13 @@ import {
     OrderedList,
     Text,
 } from '@chakra-ui/react'
-import React, { useContext } from 'react'
-import {
-    TutorialContext,
-    TutorialContextProps,
-} from '../../contexts/TutorialContext'
+import React from 'react'
+import { useTutorialContext } from '../../contexts/TutorialContext'
 import { isNASpecies } from '../../utils/species'
 import NABadge from './NABadge'
 
 const TutorialAnswers: React.FC = () => {
-    const { tutorial } = useContext(TutorialContext) as TutorialContextProps
+    const { tutorial } = useTutorialContext()
 
     if (!tutorial) return null
 

--- a/components/tutorial/TutorialCommands.tsx
+++ b/components/tutorial/TutorialCommands.tsx
@@ -1,7 +1,7 @@
 import { Button, HStack, Icon, Tooltip } from '@chakra-ui/react'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
-import React, { useContext } from 'react'
+import React from 'react'
 import {
     FaArrowLeft,
     FaCheck,
@@ -11,10 +11,7 @@ import {
 } from 'react-icons/fa'
 import { HOMEPAGE } from '../../constants/clientRoutes'
 import { strings } from '../../constants/strings'
-import {
-    TutorialContext,
-    TutorialContextProps,
-} from '../../contexts/TutorialContext'
+import { useTutorialContext } from '../../contexts/TutorialContext'
 import { formatString } from '../../utils/strings'
 type Props = {
     onShowSpeciesInfo: () => void
@@ -37,11 +34,10 @@ const TutorialCommands: React.FC<Props> = ({ onShowSpeciesInfo }) => {
     const {
         tutorial,
         sessionType,
-        setIsCurrentAnswerVisible,
         isAnswersScreenVisible,
-        setIsAnswersScreenVisible,
         selectedQuestionIndex,
-    } = useContext(TutorialContext) as TutorialContextProps
+        dispatch,
+    } = useTutorialContext()
 
     if (!tutorial || !sessionType) return null
 
@@ -58,7 +54,10 @@ const TutorialCommands: React.FC<Props> = ({ onShowSpeciesInfo }) => {
                                 <Button
                                     {...commandButton}
                                     onClick={() =>
-                                        setIsCurrentAnswerVisible(true)
+                                        dispatch({
+                                            type: 'setIsCurrentAnswerVisible',
+                                            isVisible: true,
+                                        })
                                     }
                                 >
                                     <Icon as={FaQuestion} />
@@ -87,7 +86,12 @@ const TutorialCommands: React.FC<Props> = ({ onShowSpeciesInfo }) => {
                         >
                             <Button
                                 {...commandButton}
-                                onClick={() => setIsAnswersScreenVisible(true)}
+                                onClick={() =>
+                                    dispatch({
+                                        type: 'setIsAnswersScreenVisible',
+                                        isVisible: true,
+                                    })
+                                }
                             >
                                 <Icon as={FaCheckDouble} />
                             </Button>
@@ -104,7 +108,12 @@ const TutorialCommands: React.FC<Props> = ({ onShowSpeciesInfo }) => {
                     >
                         <Button
                             {...commandButton}
-                            onClick={() => setIsAnswersScreenVisible(false)}
+                            onClick={() =>
+                                dispatch({
+                                    type: 'setIsAnswersScreenVisible',
+                                    isVisible: false,
+                                })
+                            }
                         >
                             <Icon as={FaArrowLeft} />
                         </Button>

--- a/components/tutorial/TutorialItem.tsx
+++ b/components/tutorial/TutorialItem.tsx
@@ -1,10 +1,7 @@
 import { Box, Center, HStack, Image, Text } from '@chakra-ui/react'
-import React, { useContext } from 'react'
+import React from 'react'
 import { strings } from '../../constants/strings'
-import {
-    TutorialContext,
-    TutorialContextProps,
-} from '../../contexts/TutorialContext'
+import { useTutorialContext } from '../../contexts/TutorialContext'
 import { Question } from '../../types/tutorial'
 import { isNASpecies } from '../../utils/species'
 import { formatString } from '../../utils/strings'
@@ -17,9 +14,7 @@ type Props = {
 }
 
 const TutorialItem: React.FC<Props> = ({ question, index }) => {
-    const { isCurrentAnswerVisible } = useContext(
-        TutorialContext
-    ) as TutorialContextProps
+    const { isCurrentAnswerVisible } = useTutorialContext()
 
     return (
         <Box boxSize="full" flex="none" position="relative">


### PR DESCRIPTION
Refactors TutorialContext and CatalogContext to be exposed only via custom hooks. Moves to using reducers for internal state and exposing actions for state mutation.